### PR TITLE
Added Password Change

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,12 +70,10 @@
 			<groupId>org.thymeleaf.extras</groupId>
 			<artifactId>thymeleaf-extras-springsecurity6</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-validation</artifactId>

--- a/src/main/java/group/project/bookarchive/config/SecurityConfig.java
+++ b/src/main/java/group/project/bookarchive/config/SecurityConfig.java
@@ -25,7 +25,9 @@ public class SecurityConfig {
                         .defaultSuccessUrl("/homepage?loginsuccess", true)
                         .permitAll())
                 .logout((logout) -> logout
-                        .logoutSuccessUrl("/login?logoutsuccess"));
+                        .logoutSuccessUrl("/login?logoutsuccess"))
+                .passwordManagement(customizer -> customizer
+                        .changePasswordPage("/change-password"));
         return http.build();
     }
 

--- a/src/main/java/group/project/bookarchive/controllers/ArchiveController.java
+++ b/src/main/java/group/project/bookarchive/controllers/ArchiveController.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import group.project.bookarchive.models.SignupFormDTO;
 import group.project.bookarchive.models.User;
@@ -95,4 +96,35 @@ public class ArchiveController {
         return "redirect:/login?signupsuccess";
     }
 
+
+    // mapping for change password page
+    @GetMapping("/passwordchange")
+    public String changePassword() {
+        return "passwordchange";
+    }
+    // post for change password
+    @PostMapping("/change-password")
+    public String changePassword(@AuthenticationPrincipal SecurityUser user,
+                                 @RequestParam("current-password") String currentPassword,
+                                 @RequestParam("new-password") String newPassword,
+                                 @RequestParam("confirm-password") String confirmPassword,
+                                 Model model) {
+        if (!newPassword.equals(confirmPassword)) {
+            model.addAttribute("error", "New password and confirmation do not match");
+            return "passwordchange";
+        }
+
+        User currentUser = userRepository.findByUsername(user.getUsername()).orElseThrow(() -> new RuntimeException("User not found"));
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        if (!passwordEncoder.matches(currentPassword, currentUser.getPassword())) {
+            model.addAttribute("error", "Current password is incorrect");
+            return "passwordchange";
+        }
+
+        currentUser.setPassword(passwordEncoder.encode(newPassword));
+        userRepository.save(currentUser);
+
+        return "redirect:/homepage?passwordchangesuccess";
+    }
 }

--- a/src/main/resources/templates/homepage.html
+++ b/src/main/resources/templates/homepage.html
@@ -72,6 +72,11 @@
             </div>
         </div>
     </div>
+    <div>
+        <a href="/passwordchange" style="text-decoration: none;">
+            <button type="button">Change Password</button>
+        </a>
+    </div>
     <script src="/javascript/dropDown.js"></script>
 </body>
 

--- a/src/main/resources/templates/passwordchange.html
+++ b/src/main/resources/templates/passwordchange.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org" lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Change Password</title>
+</head>
+<body>
+<h1>Change Password</h1>
+<form th:action="@{/change-password}" th:method="post">
+    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+    <div>
+        <label for="current-password">Current Password</label>
+        <input type="password" id="current-password" name="current-password" required>
+    </div>
+    <div>
+        <label for="new-password">New Password</label>
+        <input type="password" id="new-password" name="new-password" required>
+    </div>
+    <div>
+        <label for="confirm-password">Confirm New Password</label>
+        <input type="password" id="confirm-password" name="confirm-password" required>
+    </div>
+    <button type="submit">Change Password</button>
+</form>
+</body>
+</html>


### PR DESCRIPTION
SecurityConfig: add password management functionality

- Integrated password management into SecurityConfig.
- Configured custom password change page at "/change-password".
- Ensured logout success URL redirects to "/login?logoutsuccess" after successful logout.

ArchiveController: add endpoints for password change

- Added GET mapping for "/passwordchange" to render the password change page.
- Added POST mapping for "/change-password" to handle password change submissions.
- Implemented password matching validation to ensure new password and confirmation match.
- Added current password validation to verify the user's existing password before allowing changes.
- Included password encoding and updating of user password in the database.

passwordchange.html: create password change form

- Developed a form for password changes with fields for current password, new password, and confirm new password.
- Ensured form includes CSRF token for security purposes.
- Added labels and required attributes for form fields to enhance user experience and validation.

Extra Info
1. I added the button to the bottom of homepage currently, just for simplicity sakes. Change it to where y'all think we really need it.
2. The code in my passwordchange.html is rather simple, so if you need a password change anywhere else, just copy and paste the form. May need a bit of tweaking.
3. Checked that new password is encoded when pushed to the database.