### PR TITLE
fixed the admin link

### DIFF
--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -28,7 +28,7 @@
                 <a href="/profilesetting" class="dropdown-menu-list">Profile</a>
                 <a href="/passwordchange" style="text-decoration: none;">
                     Change Password</a>
-                <a href ="/admin/users" sec:authorize="${hasRole('[ROLE_ADMIN]')}" class="dropdown-menu-list"> User List</a>
+                <a href ="/admin/users" sec:authorize="${hasRole('ROLE_ADMIN')}" class="dropdown-menu-list"> User List</a>
                 <!--"link" to submit form with csrf token and log out-->
                 <form th:action="@{/logout}" method="post">
                     <a href="#" class="dropdown-menu-list" onclick="this.closest('form').submit();return false;">Log out</a>


### PR DESCRIPTION
The 'User list' link on the header dropdown menu should be visible when the admin account login
fixed `sec:authorize="${hasRole('USER_ADMIN')}"`