### PR TITLE
Fix Delete Bookshelf Functionality to Use ID

### DIFF
--- a/src/main/java/group/project/bookarchive/controllers/BookshelfController.java
+++ b/src/main/java/group/project/bookarchive/controllers/BookshelfController.java
@@ -34,8 +34,8 @@ public class BookshelfController {
 
     @PostMapping("/delete")
     public ResponseEntity<Void> deleteBookshelf(@RequestBody Map<String, String> request) {
-        String name = request.get("name");
-        bookshelfService.deleteBookshelf(name);
+        Long id = Long.parseLong(request.get("id"));
+        bookshelfService.deleteBookshelf(id);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/group/project/bookarchive/models/Bookshelf.java
+++ b/src/main/java/group/project/bookarchive/models/Bookshelf.java
@@ -8,9 +8,10 @@ public class Bookshelf {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    private String name;
-    private boolean isSecret;
 
+    private String name;
+
+    private boolean isSecret;
 
     @Column(name = "user_id")
     private Long userId;

--- a/src/main/java/group/project/bookarchive/repositories/BookshelfRepository.java
+++ b/src/main/java/group/project/bookarchive/repositories/BookshelfRepository.java
@@ -1,11 +1,15 @@
 package group.project.bookarchive.repositories;
 
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.stereotype.Repository;
 import group.project.bookarchive.models.Bookshelf;
 
 public interface BookshelfRepository extends JpaRepository<Bookshelf, Long> {
     Bookshelf findByName(String name);
+
     List<Bookshelf> findByUserId(Long userId);
+
+    Optional<Bookshelf> findById(Long id);
 }

--- a/src/main/java/group/project/bookarchive/services/BookshelfService.java
+++ b/src/main/java/group/project/bookarchive/services/BookshelfService.java
@@ -2,6 +2,8 @@ package group.project.bookarchive.services;
 
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import group.project.bookarchive.models.Bookshelf;
@@ -38,10 +40,10 @@ public class BookshelfService {
         return bookshelf;
     }
 
-    public void deleteBookshelf(String name) {
-        Bookshelf bookshelf = bookshelfRepository.findByName(name);
+    public void deleteBookshelf(Long id) {
+        Optional<Bookshelf> bookshelf = bookshelfRepository.findById(id);
         if (bookshelf != null) {
-            bookshelfRepository.delete(bookshelf);
+            bookshelfRepository.delete(bookshelf.get());
         }
     }
 

--- a/src/main/resources/static/javascript/bookshelf.js
+++ b/src/main/resources/static/javascript/bookshelf.js
@@ -7,6 +7,7 @@ document.addEventListener("DOMContentLoaded", function() {
 
 
     let currentBookshelfName = '';
+    let currentBookshelfId = '';
 
     // Event delegation for edit buttons
     document.getElementById('collection-cardlist').addEventListener('click', function(event) {
@@ -14,12 +15,15 @@ document.addEventListener("DOMContentLoaded", function() {
             // Populate the modal with the current bookshelf data
             const bookshelfElement = event.target.parentElement;
             const titleElement = bookshelfElement.querySelector('.collection-title');
+            const idElement = bookshelfElement.querySelector('.bookshelfId');
             const isSecret = bookshelfElement.querySelector('.card-lock') !== null;
 
             currentBookshelfName = titleElement.innerText;
+            currentBookshelfId = idElement.innerText;
 
             document.getElementById("edit-bookshelf-name").value = titleElement.innerText;
             document.getElementById("edit-secret-checkbox").checked = isSecret;
+            document.getElementById("edit-bookshelf-id").value = idElement.innerText;
 
             // Show the modal
             modal.style.display = "flex";
@@ -68,7 +72,7 @@ document.addEventListener("DOMContentLoaded", function() {
                     titleElement.innerText = editedName;
                     if (isSecret) {
                         if (!bookshelfElements[i].querySelector('.card-lock')) {
-                            bookshelfElements[i].querySelector('.card-description-li').insertAdjacentHTML("beforeend", '<span class="card-lock">🔒</span>');
+                            bookshelfElements[i].querySelector('.card-description-li').insertAdjacentHTML("beforeend", '<li class="card-lock">🔒</li>');
                         }
                     } else {
                         const lockElement = bookshelfElements[i].querySelector('.card-lock');
@@ -97,14 +101,16 @@ document.addEventListener("DOMContentLoaded", function() {
                     'Content-Type': 'application/json',
                     [csrf.header]: csrf.token
                 },
-                body: JSON.stringify({ name: currentBookshelfName })
+                body: JSON.stringify({ 
+                    id: currentBookshelfId
+                 })
             }).then(() => {
                 // Remove the bookshelf element from the DOM
                 const bookshelfUL = document.getElementById('collection-cardlist');
                 const bookshelfElements = bookshelfUL.getElementsByClassName('collection-li');
                 for (let i = 0; i < bookshelfElements.length; i++) {
-                    const titleElement = bookshelfElements[i].querySelector('.collection-title');
-                    if (titleElement && titleElement.innerText === currentBookshelfName) {
+                    const idElement = bookshelfElements[i].querySelector('.bookshelfId');
+                    if (idElement && idElement.innerText === currentBookshelfId) {
                         bookshelfElements[i].remove();
                         break;
                     }
@@ -207,7 +213,8 @@ function createBookshelf() {
                     <ul class="card-description-li">
                         <li class="collection-title">${data.name}</li>
                         <li class="card-numOfBooks">${data.books} Books</li>
-                        ${data.secret ? '<span class="card-lock">🔒</span>' : ""}
+                        ${data.secret ? '<li class="card-lock">🔒</li>' : ""}
+                        <li class="booshelfId" style="display:none;">${data.id}</li>
                     </ul>
                     
                     <button class="edit-btn">Edit</button>
@@ -257,7 +264,8 @@ document.getElementById("sort-books-btn").addEventListener("click", function() {
                         <ul class="card-description-li">
                             <li class="collection-title">${bookshelf.name}</li>
                             <li class="card-numOfBooks">${bookshelf.books} Books</li>
-                            ${bookshelf.secret ? '<span class="card-lock">🔒</span>' : ""}
+                            ${bookshelf.secret ? '<li class="card-lock">🔒</li>' : ""}
+                            <li class="booshelfId" style="display:none;">${bookshelf.id}</li>
                         </ul>
                         <button class="edit-btn">Edit</button>
                     </div>
@@ -328,9 +336,13 @@ document.addEventListener("DOMContentLoaded", function() {
                 numOfBooksListItem.className = "card-numOfBooks";
                 numOfBooksListItem.innerText = `${bookshelf.books} Books`;
 
+                // Append list items to the card description list
+                cardDescriptionList.appendChild(titleListItem);
+                cardDescriptionList.appendChild(numOfBooksListItem);
+
                 // Create lock element if the bookshelf is locked
                 if (data.secret) {
-                    const lockElement = document.createElement("span");
+                    const lockElement = document.createElement("li");
                     lockElement.className="card-lock";
                     lockElement.innerText = "🔒";
                     cardDescriptionList.appendChild(lockElement);
@@ -341,9 +353,13 @@ document.addEventListener("DOMContentLoaded", function() {
                 editButton.className = 'edit-btn';
                 editButton.innerText = 'Edit';
 
-                // Append list items to the card description list
-                cardDescriptionList.appendChild(titleListItem);
-                cardDescriptionList.appendChild(numOfBooksListItem);
+                // Create id holder
+                const idHolder = document.createElement('li');
+                idHolder.style.setProperty('display','none');
+                idHolder.className = 'bookshelfId';
+                idHolder.innerText = bookshelf.id;
+
+                cardDescriptionList.appendChild(idHolder);
 
                 // Append the card description list to the card description div
                 cardDescription.appendChild(cardDescriptionList);

--- a/src/main/resources/templates/homepage.html
+++ b/src/main/resources/templates/homepage.html
@@ -155,6 +155,7 @@
             <h2>Edit your bookshelf</h2>
             <label for="edit-bookshelf-name">Name</label>
             <input type="text" id="edit-bookshelf-name" placeholder="Bookshelf Name">
+            <input type="hidden" id="edit-bookshelf-id" value="bookshelfId">
             <div class="checkbox-container">
                 <input type="checkbox" id="edit-secret-checkbox">
                 <label for="edit-secret-checkbox">Keep this bookshelf secret</label>


### PR DESCRIPTION
# Issue
The delete functionality did not work correctly when multiple bookshelves had the same name. The deletion process has been updated to use the unique ID of the bookshelf instead of the name. Below are the detailed changes made:

# Changes

###  `BookshelfService.java`

Updated the `deleteBookshelf` method to accept an ID and delete the bookshelf based on this ID.

### `BookshelfController.java`

Updated the `deleteBookshelf` endpoint to parse the ID from the request and call the service method with this ID.

### `homepage.html`

Ensured that each bookshelf item contains a hidden element for the bookshelf ID.

### `bookshelf.js`

Updated the event listener to correctly select the ID element within the DOM.